### PR TITLE
Removed react-css-themr from the components

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import FontIcon from '../font_icon';
 import omit from 'lodash.omit';
+import theme from './theme.css';
 
 class Button extends Component {
   static propTypes = {
@@ -22,17 +23,6 @@ class Button extends Component {
     onMouseUp: PropTypes.func,
     primary: PropTypes.bool,
     processing: PropTypes.bool,
-    theme: PropTypes.shape({
-      button: PropTypes.string,
-      bordered: PropTypes.string,
-      icon: PropTypes.string,
-      inverse: PropTypes.string,
-      primary: PropTypes.string,
-      secondary: PropTypes.string,
-      small: PropTypes.string,
-      medium: PropTypes.string,
-      large: PropTypes.string,
-    }),
     type: PropTypes.string,
   };
 
@@ -96,7 +86,6 @@ class Button extends Component {
       href,
       icon,
       label,
-      theme,
       type,
       processing,
       ...others

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { BUTTON } from '../identifiers';
 import InjectFontIcon from '../font_icon/FontIcon';
 import omit from 'lodash.omit';
+import theme from './theme.css';
 
 const factory = (FontIcon) => {
   class IconButton extends Component {
@@ -22,16 +21,6 @@ const factory = (FontIcon) => {
       onMouseLeave: PropTypes.func,
       onMouseUp: PropTypes.func,
       primary: PropTypes.bool,
-      theme: PropTypes.shape({
-        button: PropTypes.string,
-        flat: PropTypes.string,
-        icon: PropTypes.string,
-        iconOnly: PropTypes.string,
-        inverse: PropTypes.string,
-        neutral: PropTypes.string,
-        primary: PropTypes.string,
-        toggle: PropTypes.string,
-      }),
       type: PropTypes.string,
     };
 
@@ -72,7 +61,6 @@ const factory = (FontIcon) => {
         inverse,
         neutral,
         primary,   // eslint-disable-line
-        theme,
         type,
         ...others
       } = this.props;
@@ -121,6 +109,9 @@ const factory = (FontIcon) => {
 };
 
 const IconButton = factory(InjectFontIcon);
-export default themr(BUTTON)(IconButton);
-export { factory as iconButtonFactory };
-export { IconButton };
+
+export default IconButton;
+export {
+  factory as iconButtonFactory,
+  IconButton,
+};

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -1,16 +1,11 @@
-import { themr } from 'react-css-themr';
-import { BUTTON } from '../identifiers';
-
 import Button from './Button';
 import { iconButtonFactory } from './IconButton';
 import { FontIcon } from '../font_icon/FontIcon';
-import theme from './theme.css';
 
 const IconButton = iconButtonFactory(FontIcon);
 
-const ThemedButton = themr(BUTTON, theme)(Button);
-const ThemedIconButton = themr(BUTTON, theme)(IconButton);
-
-export default ThemedButton;
-export { ThemedButton as Button };
-export { ThemedIconButton as IconButton };
+export default Button;
+export {
+  Button,
+  IconButton,
+};

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -91,8 +91,6 @@ const factory = (Overlay, Button, IconButton) => {
             onMouseDown={onOverlayMouseDown}
             onMouseMove={onOverlayMouseMove}
             onMouseUp={onOverlayMouseUp}
-            theme={theme}
-            themeNamespace="overlay"
           />
           <div
             data-teamleader-ui="dialog"

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { DIALOG } from '../identifiers.js';
 import Portal from '../hoc/Portal';
 import ActivableRenderer from '../hoc/ActivableRenderer';
 import FontIcon from '../font_icon';
 import InjectButton from '../button/Button.js';
 import InjectIconButton from '../button/IconButton';
 import InjectOverlay from '../overlay/Overlay';
+import theme from './theme.css';
 
 const factory = (Overlay, Button, IconButton) => {
   class Dialog extends Component {
@@ -29,19 +28,6 @@ const factory = (Overlay, Button, IconButton) => {
       onOverlayMouseMove: PropTypes.func,
       onOverlayMouseUp: PropTypes.func,
       size: PropTypes.oneOf([ 'small', 'medium', 'large', 'fullscreen' ]),
-      theme: PropTypes.shape({
-        active: PropTypes.string,
-        arrow: PropTypes.string,
-        body: PropTypes.string,
-        button: PropTypes.string,
-        close: PropTypes.string,
-        dialog: PropTypes.string,
-        header: PropTypes.string,
-        navigation: PropTypes.string,
-        overlay: PropTypes.string,
-        title: PropTypes.string,
-        wrapper: PropTypes.string,
-      }),
       title: PropTypes.string,
       type: PropTypes.oneOf([ 'regular', 'warning' ]),
     };
@@ -68,7 +54,6 @@ const factory = (Overlay, Button, IconButton) => {
         onOverlayMouseMove,
         onOverlayMouseUp,
         size,
-        theme,
         title,
         type,
       } = this.props;
@@ -140,6 +125,9 @@ const factory = (Overlay, Button, IconButton) => {
 };
 
 const Dialog = factory(InjectOverlay, InjectButton, InjectIconButton);
-export default themr(DIALOG)(Dialog);
-export { Dialog };
-export { factory as dialogFactory };
+
+export default Dialog;
+export {
+  Dialog,
+  factory as dialogFactory,
+};

--- a/components/dialog/index.js
+++ b/components/dialog/index.js
@@ -1,12 +1,10 @@
-import { themr } from 'react-css-themr';
-import { DIALOG } from '../identifiers';
 import { dialogFactory } from './Dialog';
 import { Overlay } from '../overlay';
 import { Button, IconButton } from '../button';
-import theme from './theme.css';
 
 const Dialog = dialogFactory(Overlay, Button, IconButton);
-const ThemedDialog = themr(DIALOG, theme)(Dialog);
 
-export default ThemedDialog;
-export { ThemedDialog as Dialog };
+export default Dialog;
+export {
+  Dialog,
+};

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,3 @@
-export const OVERLAY = 'TLOverlay';
 export const POPOVER_VERTICAL = 'TLPopoverVertical';
 export const POPOVER_HORIZONTAL = 'TLPopoverHorizontal';
 export const RADIO = 'TLRadio';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,2 +1,1 @@
-export const RADIO = 'TLRadio';
 export const TOAST = 'TLToast';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,1 +1,0 @@
-export const TOAST = 'TLToast';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,3 @@
-export const LOADING_MOLECULE = 'TLLoadingMolecule';
 export const MENU = 'TLMenu';
 export const OVERLAY = 'TLOverlay';
 export const POPOVER_VERTICAL = 'TLPopoverVertical';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,3 @@
-export const DIALOG = 'TLDialog';
 export const LOADING_MOLECULE = 'TLLoadingMolecule';
 export const MENU = 'TLMenu';
 export const OVERLAY = 'TLOverlay';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,3 @@
-export const BUTTON = 'TLButton';
 export const DIALOG = 'TLDialog';
 export const LOADING_MOLECULE = 'TLLoadingMolecule';
 export const MENU = 'TLMenu';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,3 @@
-export const MENU = 'TLMenu';
 export const OVERLAY = 'TLOverlay';
 export const POPOVER_VERTICAL = 'TLPopoverVertical';
 export const POPOVER_HORIZONTAL = 'TLPopoverHorizontal';

--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -1,4 +1,2 @@
-export const POPOVER_VERTICAL = 'TLPopoverVertical';
-export const POPOVER_HORIZONTAL = 'TLPopoverHorizontal';
 export const RADIO = 'TLRadio';
 export const TOAST = 'TLToast';

--- a/components/loadingMolecule/LoadingMolecule.js
+++ b/components/loadingMolecule/LoadingMolecule.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { themr } from 'react-css-themr';
 import cx from 'classnames';
-import { LOADING_MOLECULE } from '../identifiers.js';
+import theme from './theme.css';
 
 class LoadingMolecule extends Component {
   static defaultProps = {
@@ -14,9 +13,6 @@ class LoadingMolecule extends Component {
 
   static propTypes = {
     className: PropTypes.string,
-    theme: PropTypes.shape({
-      loadingMolecule: PropTypes.string,
-    }),
     basePath: PropTypes.string.isRequired,
     startColor: PropTypes.string.isRequired,
     stopColor: PropTypes.string.isRequired,
@@ -31,7 +27,6 @@ class LoadingMolecule extends Component {
   render () {
     const {
       className,
-      theme,
       basePath,
       startColor,
       stopColor,
@@ -95,5 +90,4 @@ class LoadingMolecule extends Component {
   }
 }
 
-export default themr(LOADING_MOLECULE)(LoadingMolecule);
-export { LoadingMolecule };
+export default LoadingMolecule;

--- a/components/loadingMolecule/index.js
+++ b/components/loadingMolecule/index.js
@@ -1,11 +1,6 @@
-import { themr } from 'react-css-themr';
-import { LOADING_MOLECULE } from '../identifiers';
-import { LoadingMolecule } from './LoadingMolecule';
-import theme from './theme.css';
+import LoadingMolecule from './LoadingMolecule';
 
-const applyTheme = Component => themr(LOADING_MOLECULE, theme)(Component);
-
-const ThemedLoadingMolecule = applyTheme(LoadingMolecule);
-
-export default ThemedLoadingMolecule;
-export { ThemedLoadingMolecule as LoadingMolecule };
+export default LoadingMolecule;
+export {
+  LoadingMolecule,
+};

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -69,7 +69,6 @@ const factory = (IconButton, Menu) => {
             position={position}
             selectable={selectable}
             selected={selected}
-            theme={theme}
           >
             {children}
           </Menu>

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { MENU } from '../identifiers.js';
 import InjectIconButton from '../button/IconButton.js';
 import InjectMenu from './Menu.js';
+import theme from './theme.css';
 
 const factory = (IconButton, Menu) => {
   class IconMenu extends Component {
@@ -22,10 +21,6 @@ const factory = (IconButton, Menu) => {
       position: PropTypes.string,
       selectable: PropTypes.bool,
       selected: PropTypes.any,
-      theme: PropTypes.shape({
-        icon: PropTypes.string,
-        iconMenu: PropTypes.string,
-      }),
     };
 
     static defaultProps = {
@@ -56,7 +51,7 @@ const factory = (IconButton, Menu) => {
     render () {
       const {
         children, className, icon, onHide, // eslint-disable-line
-        onSelect, onShow, position, selectable, selected, theme, ...other
+        onSelect, onShow, position, selectable, selected, ...other
       } = this.props;
 
       return (
@@ -87,6 +82,9 @@ const factory = (IconButton, Menu) => {
 };
 
 const IconMenu = factory(InjectIconButton, InjectMenu);
-export default themr(MENU)(IconMenu);
-export { factory as iconMenuFactory };
-export { IconMenu };
+
+export default IconMenu;
+export {
+  factory as iconMenuFactory,
+  IconMenu,
+};

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { MENU } from '../identifiers.js';
 import { events } from '../utils';
 import { getViewport } from '../utils/utils';
 import InjectMenuItem from './MenuItem.js';
+import theme from './theme.css';
 
 const POSITION = {
   AUTO: 'auto',
@@ -30,17 +29,6 @@ const factory = (MenuItem) => {
       position: PropTypes.oneOf(Object.keys(POSITION).map(key => POSITION[key])),
       selectable: PropTypes.bool,
       selected: PropTypes.any,
-      theme: PropTypes.shape({
-        active: PropTypes.string,
-        bottomLeft: PropTypes.string,
-        bottomRight: PropTypes.string,
-        menu: PropTypes.string,
-        menuInner: PropTypes.string,
-        outline: PropTypes.string,
-        static: PropTypes.string,
-        topLeft: PropTypes.string,
-        topRight: PropTypes.string,
-      }),
     };
 
     static defaultProps = {
@@ -227,7 +215,6 @@ const factory = (MenuItem) => {
     }
 
     render () {
-      const { theme } = this.props;
       const outlineStyle = { width: this.state.width, height: this.state.height };
       const className = cx([ theme.menu, theme[this.state.position] ], {
         [theme.active]: this.state.active,
@@ -250,6 +237,8 @@ const factory = (MenuItem) => {
 };
 
 const Menu = factory(InjectMenuItem);
-export default themr(MENU)(Menu);
-export { factory as menuFactory };
-export { Menu };
+export default Menu;
+export {
+  factory as menuFactory,
+  Menu,
+};

--- a/components/menu/MenuDivider.js
+++ b/components/menu/MenuDivider.js
@@ -1,17 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { themr } from 'react-css-themr';
-import { MENU } from '../identifiers.js';
+import theme from './theme.css';
 
-const MenuDivider = ({ theme }) => (
+const MenuDivider = () => (
   <hr data-teamleader-ui="menu-divider" className={theme.menuDivider} />
 );
 
-MenuDivider.propTypes = {
-  theme: PropTypes.shape({
-    menuDivider: PropTypes.string,
-  }),
+export default MenuDivider;
+export {
+  MenuDivider,
 };
-
-export default themr(MENU)(MenuDivider);
-export { MenuDivider };

--- a/components/menu/MenuItem.js
+++ b/components/menu/MenuItem.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { MENU } from '../identifiers.js';
 import FontIcon from '../font_icon/FontIcon.js';
+import theme from './theme.css';
 
 const factory = () => {
   class MenuItem extends Component {
@@ -19,14 +18,6 @@ const factory = () => {
       onClick: PropTypes.func,
       selected: PropTypes.bool,
       shortcut: PropTypes.string,
-      theme: PropTypes.shape({
-        caption: PropTypes.string,
-        disabled: PropTypes.string,
-        icon: PropTypes.string,
-        menuItem: PropTypes.string,
-        selected: PropTypes.string,
-        shortcut: PropTypes.string,
-      }),
     };
 
     static defaultProps = {
@@ -49,7 +40,6 @@ const factory = () => {
         shortcut,
         selected,
         disabled,
-        theme,
         ...others
       } = this.props;
 
@@ -77,6 +67,9 @@ const factory = () => {
 };
 
 const MenuItem = factory();
-export default themr(MENU)(MenuItem);
-export { factory as menuItemFactory };
-export { MenuItem };
+
+export default MenuItem;
+export {
+  factory as menuItemFactory,
+  MenuItem,
+};

--- a/components/menu/index.js
+++ b/components/menu/index.js
@@ -1,21 +1,17 @@
-import { themr } from 'react-css-themr';
-import { MENU } from '../identifiers';
 import { IconButton } from '../button';
 import { MenuDivider } from './MenuDivider';
 import { menuItemFactory } from './MenuItem';
 import { menuFactory } from './Menu';
 import { iconMenuFactory } from './IconMenu';
-import theme from './theme.css';
 
-const applyTheme = Component => themr(MENU, theme)(Component);
+const MenuItem = menuItemFactory();
+const Menu = menuFactory(MenuItem);
+const IconMenu = iconMenuFactory(IconButton, Menu);
 
-const ThemedMenuDivider = applyTheme(MenuDivider);
-const ThemedMenuItem = applyTheme(menuItemFactory());
-const ThemedMenu = applyTheme(menuFactory(ThemedMenuItem));
-const ThemedIconMenu = applyTheme(iconMenuFactory(IconButton, ThemedMenu));
-
-export default ThemedMenu;
-export { ThemedMenuDivider as MenuDivider };
-export { ThemedMenuItem as MenuItem };
-export { ThemedMenu as Menu };
-export { ThemedIconMenu as IconMenu };
+export default Menu;
+export {
+  MenuDivider,
+  MenuItem,
+  Menu,
+  IconMenu,
+};

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { OVERLAY } from '../identifiers';
+import theme from './theme.css';
 
 class Overlay extends Component {
   static propTypes = {
@@ -13,11 +12,6 @@ class Overlay extends Component {
     lockScroll: PropTypes.bool,
     onClick: PropTypes.func,
     onEscKeyDown: PropTypes.func,
-    theme: PropTypes.shape({
-      active: PropTypes.string,
-      backdrop: PropTypes.string,
-      overlay: PropTypes.string,
-    }),
   };
 
   static defaultProps = {
@@ -88,7 +82,6 @@ class Overlay extends Component {
       className,
       backdrop,
       lockScroll, // eslint-disable-line
-      theme,
       onEscKeyDown, // eslint-disable-line
       ...other
     } = this.props; // eslint-disable-line
@@ -110,5 +103,5 @@ class Overlay extends Component {
   }
 }
 
-export default themr(OVERLAY)(Overlay);
+export default Overlay;
 export { Overlay };

--- a/components/overlay/index.js
+++ b/components/overlay/index.js
@@ -1,8 +1,6 @@
-import { themr } from 'react-css-themr';
-import { OVERLAY } from '../identifiers';
 import { Overlay } from './Overlay';
-import theme from './theme.css';
 
-const ThemedOverlay = themr(OVERLAY, theme)(Overlay);
-export default ThemedOverlay;
-export { ThemedOverlay as Overlay };
+export default Overlay;
+export {
+  Overlay,
+};

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -142,8 +142,6 @@ const factory = (axis, calculatePositions, Overlay, Button) => {
             onMouseDown={onOverlayMouseDown}
             onMouseMove={onOverlayMouseMove}
             onMouseUp={onOverlayMouseUp}
-            theme={theme}
-            themeNamespace="overlay"
           />
           <div
             data-teamleader-ui={`popover-${axis}`}

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -7,9 +7,8 @@ import Portal from '../hoc/Portal';
 import InjectButton from '../button';
 import InjectOverlay from '../overlay';
 import { events } from '../utils';
-import { themr } from 'react-css-themr';
-import { POPOVER_HORIZONTAL, POPOVER_VERTICAL } from '../identifiers';
 import { calculateHorizontalPositions, calculateVerticalPositions } from './positionCalculation';
+import theme from './theme.css';
 
 const factory = (axis, calculatePositions, Overlay, Button) => {
   class Popover extends Component {
@@ -33,20 +32,6 @@ const factory = (axis, calculatePositions, Overlay, Button) => {
       onOverlayMouseMove: PropTypes.func,
       onOverlayMouseUp: PropTypes.func,
       position: PropTypes.string.isRequired,
-      theme: PropTypes.shape({
-        active: PropTypes.string,
-        arrow: PropTypes.string,
-        body: PropTypes.string,
-        button: PropTypes.string,
-        close: PropTypes.string,
-        dialog: PropTypes.string,
-        header: PropTypes.string,
-        navigation: PropTypes.string,
-        overlay: PropTypes.string,
-        title: PropTypes.string,
-        subtitle: PropTypes.string,
-        wrapper: PropTypes.string,
-      }),
       title: PropTypes.string,
       showHeader: PropTypes.bool.isRequired,
       subtitle: PropTypes.oneOfType([ PropTypes.object, PropTypes.string ]),
@@ -122,7 +107,6 @@ const factory = (axis, calculatePositions, Overlay, Button) => {
         onOverlayMouseUp,
         subtitle,
         showHeader,
-        theme,
         title,
       } = this.props;
 
@@ -192,10 +176,16 @@ const factory = (axis, calculatePositions, Overlay, Button) => {
   return ActivableRenderer()(Popover);
 };
 
-export const PopoverHorizontal = themr(POPOVER_HORIZONTAL)(
-  factory('horizontal', calculateHorizontalPositions, InjectOverlay, InjectButton)
+export const PopoverHorizontal = factory(
+  'horizontal',
+  calculateHorizontalPositions,
+  InjectOverlay,
+  InjectButton,
 );
 
-export const PopoverVertical = themr(POPOVER_VERTICAL)(
-  factory('vertical', calculateVerticalPositions, InjectOverlay, InjectButton)
+export const PopoverVertical = factory(
+  'vertical',
+  calculateVerticalPositions,
+  InjectOverlay,
+  InjectButton,
 );

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -1,10 +1,6 @@
-import { themr } from 'react-css-themr';
-import { POPOVER_VERTICAL, POPOVER_HORIZONTAL } from '../identifiers';
 import { PopoverHorizontal, PopoverVertical } from './Popover';
-import theme from './theme.css';
 
-const ThemedPopoverVertical = themr(POPOVER_VERTICAL, theme)(PopoverVertical);
-export { ThemedPopoverVertical as PopoverVertical };
-
-const ThemedPopoverHorizontal = themr(POPOVER_HORIZONTAL, theme)(PopoverHorizontal);
-export { ThemedPopoverHorizontal as PopoverHorizontal };
+export {
+  PopoverVertical,
+  PopoverHorizontal,
+};

--- a/components/radio/Radio.js
+++ b/components/radio/Radio.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import theme from './theme.css';
 
-const Radio = ({ checked, onMouseDown, theme, ...other }) => (
+const Radio = ({ checked, onMouseDown, ...other }) => (
   <div
     data-teamleader-ui="radio"
     className={theme[checked ? 'radioChecked' : 'radio']}
@@ -14,10 +15,6 @@ Radio.propTypes = {
   checked: PropTypes.bool,
   children: PropTypes.node,
   onMouseDown: PropTypes.func,
-  theme: PropTypes.shape({
-    radio: PropTypes.string,
-    radioChecked: PropTypes.string,
-  }),
 };
 
 export default Radio;

--- a/components/radio/RadioButton.js
+++ b/components/radio/RadioButton.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { RADIO } from '../identifiers';
 import Radio from './Radio';
+import theme from './theme.css';
 
 class RadioButton extends Component {
   static propTypes = {
@@ -21,12 +20,6 @@ class RadioButton extends Component {
     onFocus: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
-    theme: PropTypes.shape({
-      disabled: PropTypes.string,
-      field: PropTypes.string,
-      input: PropTypes.string,
-      text: PropTypes.string,
-    }),
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool,
@@ -73,7 +66,6 @@ class RadioButton extends Component {
       onChange, // eslint-disable-line
       onMouseEnter,
       onMouseLeave,
-      theme,
       ...others
     } = this.props;
     const _className = cx(theme[disabled ? 'disabled' : 'field'], className);
@@ -97,7 +89,7 @@ class RadioButton extends Component {
           }}
           type="radio"
         />
-        <Radio checked={checked} disabled={disabled} theme={theme} />
+        <Radio checked={checked} disabled={disabled} />
         {label ? <span className={theme.text}>{label}</span> : null}
         {children}
       </label>
@@ -105,5 +97,5 @@ class RadioButton extends Component {
   }
 }
 
-export default themr(RADIO)(RadioButton);
+export default RadioButton;
 export { RadioButton };

--- a/components/radio/RadioGroup.js
+++ b/components/radio/RadioGroup.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { themr } from 'react-css-themr';
-import { RADIO } from '../identifiers';
 import RadioButton from './index';
 import isComponentOfType from '../utils/is-component-of-type';
 
@@ -54,5 +52,5 @@ class RadioGroup extends Component {
   }
 }
 
-export default themr(RADIO)(RadioGroup);
+export default RadioGroup;
 export { RadioGroup };

--- a/components/radio/index.js
+++ b/components/radio/index.js
@@ -1,12 +1,8 @@
-import { themr } from 'react-css-themr';
-import { RADIO } from '../identifiers';
 import { RadioButton } from './RadioButton';
 import { RadioGroup } from './RadioGroup';
-import theme from './theme.css';
 
-const ThemedRadioButton = themr(RADIO, theme)(RadioButton);
-const ThemedRadioGroup = themr(RADIO, theme)(RadioGroup);
-
-export default ThemedRadioButton;
-export { ThemedRadioButton as RadioButton };
-export { ThemedRadioGroup as RadioGroup };
+export default RadioButton;
+export {
+  RadioButton,
+  RadioGroup,
+};

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { themr } from 'react-css-themr';
-import { TOAST } from '../identifiers';
 import ActivableRenderer from '../hoc/ActivableRenderer';
 import { Button, IconButton } from '../button';
 import Portal from '../hoc/Portal';
+import theme from './theme.css';
 
 const factory = (Button, IconButton) => {
   class Toast extends Component {
@@ -20,16 +19,6 @@ const factory = (Button, IconButton) => {
       ]),
       onClick: PropTypes.func,
       onTimeout: PropTypes.func,
-      theme: PropTypes.shape({
-        accept: PropTypes.string,
-        active: PropTypes.string,
-        button: PropTypes.string,
-        cancel: PropTypes.string,
-        iconButton: PropTypes.string,
-        label: PropTypes.string,
-        toast: PropTypes.string,
-        warning: PropTypes.string,
-      }),
       timeout: PropTypes.number,
       type: PropTypes.oneOf([ 'accept', 'cancel', 'warning' ]),
     };
@@ -73,7 +62,6 @@ const factory = (Button, IconButton) => {
         children,
         label,
         onClick,
-        theme,
         type,
       } = this.props;
 
@@ -110,6 +98,9 @@ const factory = (Button, IconButton) => {
 };
 
 const Toast = factory(Button, IconButton);
-export default themr(TOAST)(Toast);
-export { factory as toastFactory };
-export { Toast };
+
+export default Toast;
+export {
+  factory as toastFactory,
+  Toast,
+};

--- a/components/toast/index.js
+++ b/components/toast/index.js
@@ -1,8 +1,4 @@
-import { themr } from 'react-css-themr';
-import { TOAST } from '../identifiers';
 import { Toast } from './Toast';
-import theme from './theme.css';
 
-const ThemedToast = themr(TOAST, theme)(Toast);
-export default ThemedToast;
-export { ThemedToast as Toast };
+export default Toast;
+export { Toast };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3672,7 +3672,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -4089,7 +4090,8 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
@@ -4589,11 +4591,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4861,6 +4858,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -7747,15 +7745,6 @@
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.5.10"
-      }
-    },
-    "react-css-themr": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-css-themr/-/react-css-themr-2.1.2.tgz",
-      "integrity": "sha1-4BdRTkccIy9Dp1SlW0nYH69dr7g=",
-      "requires": {
-        "hoist-non-react-statics": "1.2.0",
-        "invariant": "2.2.2"
       }
     },
     "react-deep-force-update": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.9",
     "react": "^15.5.4",
-    "react-css-themr": "^2.0.0",
     "react-dom": "^15.5.4"
   },
   "devDependencies": {

--- a/spec/components/toast.js
+++ b/spec/components/toast.js
@@ -70,7 +70,7 @@ class ToastTest extends React.Component {
           action={this.state.action}
           active={this.state.active}
           label={this.state.label}
-          timeout={3000}
+          timeout={9999999}
           onClick={this.handleSnackbarClick}
           onTimeout={this.handleSnackbarTimeout}
           type={this.state.type}

--- a/spec/components/toast.js
+++ b/spec/components/toast.js
@@ -70,7 +70,7 @@ class ToastTest extends React.Component {
           action={this.state.action}
           active={this.state.active}
           label={this.state.label}
-          timeout={9999999}
+          timeout={3000}
           onClick={this.handleSnackbarClick}
           onTimeout={this.handleSnackbarTimeout}
           type={this.state.type}


### PR DESCRIPTION
We decided to remove react-css-themr, because we don't need it (our designers promised us) and it was only adding extra complexity.