### PR TITLE
:sparkles: added missing teamleader ui data attibutes

### DIFF
--- a/components/island/Island.js
+++ b/components/island/Island.js
@@ -80,7 +80,7 @@ class Island extends Component {
     ]);
 
     return (
-      <div className={classes} {...rest}>
+      <div data-teamleader-ui="island" className={classes} {...rest}>
         {children}
       </div>
     );

--- a/components/loadingMolecule/LoadingMolecule.js
+++ b/components/loadingMolecule/LoadingMolecule.js
@@ -51,7 +51,7 @@ class LoadingMolecule extends Component {
     const grandient2Source = `url(${basePath}#${gradient2Name})`;
 
     return (
-      <div className={classes} {...others}>
+      <div data-teamleader-ui="loading-molecule" className={classes} {...others}>
         <svg className="loader" width="100px" height="56px" version="1.1">
           <defs>
             <linearGradient x1="63.2191022%" y1="50%" x2="21.8036493%" y2="115.713387%" id={gradient1Name}>

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -60,7 +60,7 @@ const factory = (IconButton, Menu) => {
       } = this.props;
 
       return (
-        <div {...other} className={cx(theme.iconMenu, className)}>
+        <div data-teamleader-ui="icon-menu" {...other} className={cx(theme.iconMenu, className)}>
           <IconButton
             className={theme.icon}
             icon={icon}

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -95,6 +95,7 @@ class Overlay extends Component {
 
     return (
       <div
+        data-teamleader-ui="overlay"
         {...other}
         onClick={this.handleClick}
         className={cx(

--- a/components/section/Section.js
+++ b/components/section/Section.js
@@ -80,7 +80,7 @@ class Section extends Component {
     ]);
 
     return (
-      <div className={classes} {...rest}>
+      <div data-teamleader-ui="section" className={classes} {...rest}>
         {children}
       </div>
     );

--- a/components/typography/Heading.js
+++ b/components/typography/Heading.js
@@ -31,7 +31,7 @@ const factory = (type, defaultElement) => {
       const Element = element || defaultElement;
 
       return (
-        <Element className={classNames}>{children}</Element>
+        <Element data-teamleader-ui="heading" className={classNames}>{children}</Element>
       );
     }
   }

--- a/components/typography/Monospaced.js
+++ b/components/typography/Monospaced.js
@@ -29,7 +29,7 @@ class Monospaced extends PureComponent {
     const Element = element;
 
     return (
-      <Element className={classNames}>{children}</Element>
+      <Element data-teamleader-ui="monospaced" className={classNames}>{children}</Element>
     );
   }
 }

--- a/components/typography/OldStyleNumber.js
+++ b/components/typography/OldStyleNumber.js
@@ -29,7 +29,7 @@ class OldStyleNumber extends PureComponent {
     const Element = element;
 
     return (
-      <Element className={classNames}>{children}</Element>
+      <Element data-teamleader-ui="old-styled-number" className={classNames}>{children}</Element>
     );
   }
 }

--- a/components/typography/Text.js
+++ b/components/typography/Text.js
@@ -31,7 +31,7 @@ const factory = (type, defaultElement) => {
       const Element = element || defaultElement;
 
       return (
-        <Element className={classNames}>{children}</Element>
+        <Element data-teamleader-ui="text" className={classNames}>{children}</Element>
       );
     }
   }


### PR DESCRIPTION
We forgot to add the `data-teamleader-ui` attribute on some components. Not every component needs them, but adding them anyway for consistency.