### PR TITLE
Render a semantically more correct section element

### DIFF
--- a/components/section/Section.js
+++ b/components/section/Section.js
@@ -48,9 +48,9 @@ class Section extends PureComponent {
     ]);
 
     return (
-      <div data-teamleader-ui="section" className={classes} {...rest}>
+      <section data-teamleader-ui="section" className={classes} {...rest}>
         {children}
-      </div>
+      </section>
     );
   }
 }


### PR DESCRIPTION
### Changed
- The rendered element of the Section component from a `<div>` element to a `<section>` element.