### PR TITLE
Fix production deploy

### DIFF
--- a/config/environments.js
+++ b/config/environments.js
@@ -33,7 +33,7 @@ module.exports = {
     compiler_public_path: '/',
     compiler_fail_on_warning: false,
     compiler_hash_type: 'chunkhash',
-    compiler_devtool: null,
+    compiler_devtool: false,
     compiler_stats: {
       chunks: true,
       chunkModules: true,


### PR DESCRIPTION
Apparently this value needs to be false or a string:

```
Compiler encountered an error. WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.devtool should be one of these:
   string | false
   A developer tool to enhance debugging.
```