### PR TITLE
Teal text can be soft as well

### DIFF
--- a/components/typography/Text.js
+++ b/components/typography/Text.js
@@ -19,7 +19,7 @@ const factory = (baseType, type, defaultElement) => {
     };
 
     isSoft(color) {
-      if (color !== 'white') {
+      if (color !== 'white' && color !== 'teal') {
         return false;
       }
 

--- a/components/typography/theme.css
+++ b/components/typography/theme.css
@@ -23,6 +23,10 @@
 
 .teal {
   color: var(--color-teal-darkest);
+
+  &.soft {
+    color: var(--color-neutral-darkest);
+  }
 }
 
 .violet {


### PR DESCRIPTION
Teal text can be soft as wel, for example in a disabled toggle/checkbox/radiobutton

![screen shot 2017-10-19 at 16 30 28](https://user-images.githubusercontent.com/330765/31776269-5be42304-b4eb-11e7-8748-501b5515e327.png)
