### PR TITLE
Add a static method to split in the Box components

### DIFF
--- a/components/box/Box.js
+++ b/components/box/Box.js
@@ -4,6 +4,22 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 const spacings = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+const availableProps = [
+  'margin',
+  'marginHorizontal',
+  'marginVertical',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'padding',
+  'paddingHorizontal',
+  'paddingVertical',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+];
 
 class Box extends PureComponent {
   static propTypes = {
@@ -31,6 +47,23 @@ class Box extends PureComponent {
     margin: 0,
     padding: 0,
   };
+
+  static splitProps(props) {
+    const boxProps = {};
+    const otherProps = {};
+
+    Object.keys(props).forEach(key => {
+      const value = props[key];
+
+      if (availableProps.includes(key)) {
+        boxProps[key] = value;
+      } else {
+        otherProps[key] = value;
+      }
+    });
+
+    return { boxProps, otherProps };
+  }
 
   render() {
     const {


### PR DESCRIPTION
While using the `Box` component I stumbled upon an issue where I couldn't add paddings/margins.
For example: I have a (simplified) `Toggle` component that I implemented with `Box`.

```js
class Toggle extends PureComponent {
  render() {
    const { label, ...others } = this.props;

    return (
      <Box>
        <input type="checkbox" {...others} />
        {label}
      </Box>
    );  
  }
}
```

If I would use the `Toggle` component, and I would add a padding/margin, those props would be assigned to the `input` instead of `Box`, which makes sense, because I'm destructuring them in the `input` element. I need to destructure them at that place because I want to be able to pass default checkbox props such as `disabled`, `checked`, `onChange`, ...

So I actually need a way to split off props that were meant for `Box` and other props.  I wanted to define those `Box` props only in 1 place, so I added a static method to `Box` that can split props into props for `Box` and other props.

It can then be implemented like this:

```js
class Toggle extends PureComponent {
  render() {
    const { label, ...others } = this.props;
    const { boxProps, otherProps } = Box.splitProps(others);

    return (
      <Box {...boxProps}>
        <input type="checkbox" {...otherProps} />
        {label}
      </Box>
    );  
  }
}
```

It's not the cleanest code, but I currently don't see a different way for solving this. If you know one, I would love to hear it!
