### PR TITLE
Moved the opacity transformation to the popup instead of the wrapper

### DIFF
--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -1,3 +1,4 @@
+@import '@teamleader/ui-animations';
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-utilities';
 
@@ -21,30 +22,31 @@
   display: flex;
   height: 100vh;
   justify-content: center;
-  opacity: 0;
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   z-index: var(--z-index-higher);
   transition: opacity .2s ease-out;
-
-  &.is-entering {
-    opacity: 0;
-  }
-
-  &.is-entered {
-    opacity: 1;
-  }
 }
 
 .popover {
   background: var(--popover-background-color);
   border-radius: var(--popover-border-radius);
   box-shadow: var(--popover-box-shadow);
+  opacity: 0;
   position: absolute;
+  transition: opacity var(--animation-duration) var(--animation-curve-default);
   max-width: 50vw;
   min-width: 300px;
+}
+
+.is-entering .popover {
+  opacity: 0;
+}
+
+.is-entered .popover {
+  opacity: 1;
 }
 
 .arrow {


### PR DESCRIPTION
Overlay is already animated within it's own component. So we only need to take care of the popup opacity animation. This is why I moved the opacity transformation from the wrapper (containing the Overlay) to the Popup.