### PR TITLE
ButtonGroup: added 'alignItems' prop

### DIFF
--- a/components/button/ButtonGroup.js
+++ b/components/button/ButtonGroup.js
@@ -9,13 +9,19 @@ class ButtonGroup extends PureComponent {
     children: PropTypes.node,
     className: PropTypes.string,
     segmented: PropTypes.bool,
+    alignItems: PropTypes.oneOf(['left', 'right']),
+  };
+
+  static defaultProps = {
+    alignItems: 'left',
   };
 
   render() {
-    const { children, className, segmented, ...others } = this.props;
+    const { alignItems, children, className, segmented, ...others } = this.props;
 
     const classNames = cx(
-      [theme['group']],
+      theme[`align-${alignItems}`],
+      theme['group'],
       {
         [theme['segmented']]: segmented,
       },

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -425,3 +425,11 @@
     border-radius: 0 var(--button-border-radius) var(--button-border-radius) 0;
   }
 }
+
+.align-left {
+  justify-content: flex-start;
+}
+
+.align-right {
+  justify-content: flex-end;
+}


### PR DESCRIPTION
Added 'alignItems' prop to our ButtonGroup component so we could align the buttons left or right.