### PR TITLE
fix bug where we couldn't click on something that was underneath the closed qtip

### DIFF
--- a/components/qTip/theme.css
+++ b/components/qTip/theme.css
@@ -9,6 +9,7 @@
 .container {
   position: relative;
   overflow: hidden;
+  pointer-events: none;
 }
 
 .qtip {
@@ -20,6 +21,7 @@
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
   transition: all var(--animation-duration) var(--animation-curve-default);
+  pointer-events: all;
 
   .is-closed & {
     transform: translateX(100%) translateX(calc(-1 * var(--tip-width) + 1px)); /* split into 2 separete translate, otherwise IE can't handle it */


### PR DESCRIPTION
When the qtip is closed, it still has a "bigger" transparent div, which you couldn't click through. This fixes it.