### PR TITLE
Update to latest @sambego/storybook-state

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-transition-group": "^2.2.1"
   },
   "devDependencies": {
-    "@sambego/storybook-state": "^1.0.3",
+    "@sambego/storybook-state": "^1.0.6",
     "@sambego/storybook-styles": "^1.0.0",
     "@storybook/addon-actions": "^3.2.12",
     "@storybook/addon-info": "^3.2.12",


### PR DESCRIPTION
This fixes the following console warning:

```
Warning: Component State declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?
```