### PR TITLE
Disable (webpack 4) minification

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -55,6 +55,8 @@ module.exports = (storybookBaseConfig, configType) => {
     ],
   });
 
+  storybookBaseConfig.optimization.minimize = false;
+
   storybookBaseConfig.plugins.map(plugin => {
     if (plugin instanceof webpack.DefinePlugin) {
       plugin.definitions = {


### PR DESCRIPTION
### Description

Due to the _default enabled_ `minification` in `webpack 4`, all our component names are reduced to one or two random characters:
* `<n .../>`
* `<t .../>`
* `<Kn .../>`
* ...

This PR disables the default `minification` in `webpack 4`, which solves the above issue.

#### Screenshot before this PR

![schermafdruk 2018-11-09 12 06 50](https://user-images.githubusercontent.com/5336831/48259369-063fe980-e418-11e8-9609-7c42ac2428cd.png)

![schermafdruk 2018-11-09 12 07 00](https://user-images.githubusercontent.com/5336831/48259382-0d66f780-e418-11e8-84ff-069a388e55b0.png)

#### Screenshot after this PR

![schermafdruk 2018-11-09 12 06 30](https://user-images.githubusercontent.com/5336831/48259387-11931500-e418-11e8-876c-126c02bd0b2e.png)

![schermafdruk 2018-11-09 12 07 11](https://user-images.githubusercontent.com/5336831/48259391-15269c00-e418-11e8-9484-a0bdee5afb24.png)

### Breaking changes

None.