### PR TITLE
Change input's onFocus type

### DIFF
--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -87,7 +87,7 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
     return customFormatDate(selectedDate, locale);
   };
 
-  const handleInputFocus = (event: React.SyntheticEvent<HTMLElement>) => {
+  const handleInputFocus = (event: React.FocusEvent<HTMLElement>) => {
     if (inputProps?.readOnly) {
       return;
     }
@@ -105,7 +105,7 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
     if (!openPickerOnFocus) {
       setPopoverAnchorEl(event.currentTarget);
       setIsPopoverActive(true);
-      inputProps?.onFocus && inputProps.onFocus(event);
+      inputProps?.onFocus && inputProps.onFocus(event as unknown as React.FocusEvent<HTMLElement>);
     }
 
     inputProps?.onClick && inputProps.onClick(event);

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -6,7 +6,7 @@ export interface InputProps extends Omit<SingleLineInputBaseProps, 'onChange'> {
   /** Callback function that is fired when the component's value changes. */
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => void;
   /** Callback function that is fired when the component is focussed. */
-  onFocus?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   /** Callback function that is fired when the component is clicked. */
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   /** Current value of the input element. */

--- a/src/components/input/InputBase.tsx
+++ b/src/components/input/InputBase.tsx
@@ -25,7 +25,7 @@ export interface InputBaseProps
   /** Callback function that is fired when the component's value changes. */
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   /** Callback function that is fired when focusing the input field. */
-  onFocus?: (event: FocusEvent<HTMLElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   /** Boolean indicating whether the input should render as read only. */
   readOnly?: boolean;
   /** Forwarded ref element. */


### PR DESCRIPTION
### Description

Changed input's focus type to React.FocusEvent instead of SyntheticEvent. This was throwing many type errors on core.