### PR TITLE
Added labelPosition and fullWidth props to Toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `Popover`: Aligned the popover shadows with our design spec. ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2708](https://github.com/teamleadercrm/ui/pull/2708))
-
 ### Deprecated
 
 ### Removed
@@ -19,6 +17,10 @@
 ### Added
 
 - `Toggle`: Props `labelPosition` and `fullWidth`. ([@qubis741](https://github.com/qubis741) in [#2710](https://github.com/teamleadercrm/ui/pull/2710))
+
+### Changed
+
+- `Popover`: Aligned the popover shadows with our design spec. ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2708](https://github.com/teamleadercrm/ui/pull/2708))
 
 ## [22.1.1] - 2023-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Added
 
-- `Toggle`: Props `labelPosition` and `fullWidth`. ([@qubis741](https://https://github.com/qubis741) in [#2710](https://github.com/teamleadercrm/ui/pull/2710))
+- `Toggle`: Props `labelPosition` and `fullWidth`. ([@qubis741](https://github.com/qubis741) in [#2710](https://github.com/teamleadercrm/ui/pull/2710))
 
 ## [22.1.1] - 2023-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [22.2.0] - 2023-07-11
+
+### Added
+
+- `Toggle`: Props `labelPosition` and `fullWidth`. ([@qubis741](https://https://github.com/qubis741) in [#2710](https://github.com/teamleadercrm/ui/pull/2710))
+
 ## [22.1.1] - 2023-06-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.1.1",
+  "version": "22.2.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -25,6 +25,8 @@ export interface ToggleProps
   label?: ReactNode;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   size?: Exclude<typeof SIZES[number], 'tiny' | 'fullscreen' | 'smallest' | 'hero'>;
+  labelPosition?: 'left' | 'right';
+  fullWidth?: boolean;
 }
 
 const Toggle: GenericComponent<ToggleProps> = ({
@@ -38,6 +40,8 @@ const Toggle: GenericComponent<ToggleProps> = ({
   size = 'medium',
   tooltip,
   tooltipPosition,
+  labelPosition = 'right',
+  fullWidth = false,
   ...others
 }) => {
   const ref = useRef<HTMLInputElement>(null);
@@ -55,6 +59,8 @@ const Toggle: GenericComponent<ToggleProps> = ({
     {
       [theme['is-checked']]: checked,
       [theme['is-disabled']]: disabled,
+      [theme['label-on-left']]: labelPosition === 'left',
+      [theme['is-full-width']]: fullWidth,
     },
     className,
   );

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -29,10 +29,11 @@
     overflow: hidden;
     opacity: 0;
     margin: 0;
+    position: absolute;
   }
 
   .label {
-    margin-left: var(--spacer-small);
+    margin: 0 0 0 var(--spacer-small);
     display: flex;
   }
 
@@ -110,6 +111,18 @@
         background: var(--color-neutral-lightest);
       }
     }
+  }
+
+  &.label-on-left {
+    flex-direction: row-reverse;
+    .label {
+      margin: 0 var(--spacer-small) 0 0;
+    }
+  }
+
+  &.is-full-width {
+    justify-content: space-between;
+    width: 100%;
   }
 
   input:focus-visible + .track {


### PR DESCRIPTION
## [22.2.0] - 2023-07-11

### Added

`Toggle`: Props `labelPosition` and `fullWidth`. ([@qubis741](https://https://github.com/qubis741) in [#2710](https://github.com/teamleadercrm/ui/pull/2710))




### Design
https://www.figma.com/file/Aq9Ovc5xBe93MfuPUHTNW6/New-Quotations---designs?type=design&node-id=10451-283721&mode=design&t=hPowg87zssp1apqC-0