### PR TITLE
Fraf 2895

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [25.0.3]
+
+### Fixed
+
+- `Tag`: Height of remove button ([@qubis741](https://github.com/qubis741)) in [#2834](https://github.com/teamleadercrm/ui/pull/2834)
+
 ## [25.0.2]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "25.0.2",
+  "version": "25.0.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -16,8 +16,8 @@
 .remove-button {
   border-radius: 50%;
   min-width: initial;
-  height: var(--size);
-  width: var(--size);
+  height: var(--size)!important;
+  width: var(--size)!important;
 }
 
 .is-small {


### PR DESCRIPTION
## [25.0.3]

### Fixed

- `Tag`: Height of remove button ([@qubis741](https://github.com/qubis741)) in [#2834](https://github.com/teamleadercrm/ui/pull/2834)


On prod and staging, classes are in incorrect order applied, which causes iconButton class to override `remove-button` class
![image](https://github.com/teamleadercrm/ui/assets/9944471/79eb27c1-9f12-4e33-a364-395f5c21265c)
![image](https://github.com/teamleadercrm/ui/assets/9944471/74dc43cb-5410-4e6d-b3c7-ea15d78f1647)

