### PR TITLE
Release 25.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+## [25.0.4]
+
+### Fixed
+
 - `Popover` and `Menu`: Fixed positioning in Safari when zoomed in by pinching ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2837](https://github.com/teamleadercrm/ui/pull/2837)
 
 ## [25.0.3]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "25.0.3",
+  "version": "25.0.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [25.0.4]

### Fixed

- `Popover` and `Menu`: Fixed positioning in Safari when zoomed in by pinching ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2837](https://github.com/teamleadercrm/ui/pull/2837)
